### PR TITLE
fixed formatting of english bullet point(s)

### DIFF
--- a/open-positions/full_stack_web3_curriculum_developer.md
+++ b/open-positions/full_stack_web3_curriculum_developer.md
@@ -39,8 +39,8 @@ We aren't just teaching the entry level students though, through your research, 
 - Strong knowledge of JavaScript/TypeScript and at least one modern front-end framework (React, Svelte)
 - Strong command of the english language
 - Video/on-camera experience doing educational content
-Excellent written and verbal communication skills
-Ability to explain complex technical concepts in an easy-to-understand manner
+- Excellent written and verbal communication skills
+- Ability to explain complex technical concepts in an easy-to-understand manner
 
 ## Preferred Qualifications
 


### PR DESCRIPTION
The formatting in markdown caused a single long line instead of three bullet points. i edited two missing bullet points

the random Capital letters appearing in the preview tipped me off